### PR TITLE
Alex/#11 keep log image requested in the db

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,12 +89,12 @@ model ImageGenerationRequest {
     id              String            @id @default(cuid())
     createdAt       DateTime          @default(now())
     requestText     String
-    imageSize       ImageSize         @relation(fields: [imageSizeId], references: [id])
     numberOfImages  Int
     generatedImages GeneratedImages[]
     User            User?             @relation(fields: [userId], references: [id])
     userId          String?
-    imageSizeId     String
+    ImageSize       ImageSize?        @relation(fields: [imageSizeTitle], references: [size])
+    imageSizeTitle  String?
 }
 
 model GeneratedImages {
@@ -106,7 +106,6 @@ model GeneratedImages {
 }
 
 model ImageSize {
-    id                     String                   @id @default(cuid())
-    size                   String                   @unique
+    size                   String                   @id
     ImageGenerationRequest ImageGenerationRequest[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,14 +50,15 @@ model Session {
 }
 
 model User {
-    id            String         @id @default(cuid())
-    name          String?
-    email         String?        @unique
-    emailVerified DateTime?
-    image         String?
-    accounts      Account[]
-    sessions      Session[]
-    OpenAIModels  OpenAIModels[]
+    id                     String                   @id @default(cuid())
+    name                   String?
+    email                  String?                  @unique
+    emailVerified          DateTime?
+    image                  String?
+    accounts               Account[]
+    sessions               Session[]
+    OpenAIModels           OpenAIModels[]
+    ImageGenerationRequest ImageGenerationRequest[]
 }
 
 model VerificationToken {
@@ -82,4 +83,30 @@ model OpenAIModels {
     deprecated                  Boolean?
     User                        User?     @relation(fields: [userId], references: [id])
     userId                      String?
+}
+
+model ImageGenerationRequest {
+    id              String            @id @default(cuid())
+    createdAt       DateTime          @default(now())
+    requestText     String
+    imageSize       ImageSize         @relation(fields: [imageSizeId], references: [id])
+    numberOfImages  Int
+    generatedImages GeneratedImages[]
+    User            User?             @relation(fields: [userId], references: [id])
+    userId          String?
+    imageSizeId     String
+}
+
+model GeneratedImages {
+    id                       String                  @id @default(cuid())
+    createdAt                DateTime                @default(now())
+    imageUrl                 String
+    ImageGenerationRequest   ImageGenerationRequest? @relation(fields: [imageGenerationRequestId], references: [id])
+    imageGenerationRequestId String?
+}
+
+model ImageSize {
+    id                     String                   @id @default(cuid())
+    size                   String
+    ImageGenerationRequest ImageGenerationRequest[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,6 @@ model GeneratedImages {
 
 model ImageSize {
     id                     String                   @id @default(cuid())
-    size                   String
+    size                   String                   @unique
     ImageGenerationRequest ImageGenerationRequest[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,8 +93,7 @@ model ImageGenerationRequest {
     generatedImages GeneratedImages[]
     User            User?             @relation(fields: [userId], references: [id])
     userId          String?
-    ImageSize       ImageSize?        @relation(fields: [imageSizeTitle], references: [size])
-    imageSizeTitle  String?
+    imageSize       String?
 }
 
 model GeneratedImages {
@@ -103,9 +102,4 @@ model GeneratedImages {
     imageUrl                 String
     ImageGenerationRequest   ImageGenerationRequest? @relation(fields: [imageGenerationRequestId], references: [id])
     imageGenerationRequestId String?
-}
-
-model ImageSize {
-    size                   String                   @id
-    ImageGenerationRequest ImageGenerationRequest[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,37 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 async function main() {
-  // Image Sizes
-  const imageSize256x256 = await prisma.imageSize.upsert({
-    where: {
-      size: "256x256",
-    },
-    update: {},
-    create: {
-      size: "256x256",
-    },
-  });
-
-  const imageSize512x512 = await prisma.imageSize.upsert({
-    where: {
-      size: "512x512",
-    },
-    update: {},
-    create: {
-      size: "512x512",
-    },
-  });
-
-  const imageSize1024x1024 = await prisma.imageSize.upsert({
-    where: {
-      size: "1024x1024",
-    },
-    update: {},
-    create: {
-      size: "1024x1024",
-    },
-  });
-
   //Text models
   const gpt4 = await prisma.openAIModels.upsert({
     where: {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,38 @@
 import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 async function main() {
+  // Image Sizes
+  const imageSize256x256 = await prisma.imageSize.upsert({
+    where: {
+      size: "256x256",
+    },
+    update: {},
+    create: {
+      size: "256x256",
+    },
+  });
+
+  const imageSize512x512 = await prisma.imageSize.upsert({
+    where: {
+      size: "512x512",
+    },
+    update: {},
+    create: {
+      size: "512x512",
+    },
+  });
+
+  const imageSize1024x1024 = await prisma.imageSize.upsert({
+    where: {
+      size: "1024x1024",
+    },
+    update: {},
+    create: {
+      size: "1024x1024",
+    },
+  });
+
+  //Text models
   const gpt4 = await prisma.openAIModels.upsert({
     where: {
       name: "gpt-4",

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@/utils/class-merge";
+
 type IconProps = React.HTMLAttributes<SVGElement> & {
   fill?: string;
 };
@@ -103,7 +105,10 @@ export const Icons = {
   spinner: (props: IconProps) => (
     <svg
       {...props}
-      className="-ml-1 mr-3 h-5 w-5 animate-spin text-white"
+      className={cn(
+        "-ml-1 mr-3 h-5 w-5 animate-spin text-white",
+        props.className
+      )}
       xmlns="http://www.w3.org/2000/svg"
       fill={props.fill ?? "none"}
       viewBox="0 0 24 24"

--- a/src/hooks/saveImageRequest.ts
+++ b/src/hooks/saveImageRequest.ts
@@ -1,0 +1,63 @@
+import { api } from "@/utils/api";
+import { useSession } from "next-auth/react";
+import { useState } from "react";
+
+export function useSaveImageRequest() {
+  const [userRequestId, setUserRequestId] = useState<string | undefined>(
+    undefined
+  );
+  const { data: session } = useSession();
+  const saveUserRequestMutation =
+    api.imageGenerationLog.saveUserRequest.useMutation();
+  const saveGeneratedImagesMutation =
+    api.imageGenerationLog.saveGeneratedImages.useMutation();
+
+  const getGeneratedImagesQuery =
+    api.imageGenerationLog.getAllImagesGeneratedByUser.useQuery(
+      { numberOfImages: 10 },
+      {
+        enabled: !!session,
+      }
+    );
+
+  //   useEffect(() => {
+  //     if (!getGeneratedImagesQuery.data) return;
+  //     const requests = getGeneratedImagesQuery.data?.map(
+  //       (d) => d.generatedImages
+  //     );
+  //     if (!requests) return;
+  //     const images = requests.flat().map((d) => d.imageUrl);
+  //     setGeneratedImages(images);
+  //   }, [getGeneratedImagesQuery.data, setGeneratedImages]);
+
+  const saveUserRequest = async ({
+    values,
+  }: {
+    values: { prompt: string; size: string; n: number };
+  }) => {
+    const userRequest = await saveUserRequestMutation.mutateAsync({
+      requestText: values.prompt,
+      imageSize: values.size,
+      numberOfImages: values.n,
+    });
+    setUserRequestId(userRequest.id);
+  };
+
+  const saveGeneratedImages = async (images: string[]) => {
+    if (userRequestId) {
+      await saveGeneratedImagesMutation.mutateAsync({
+        imageGenerationRequestId: userRequestId,
+        generatedImages: images,
+      });
+    }
+  };
+  const isQueryLoading = session && getGeneratedImagesQuery.isLoading;
+  const isMutationLoading =
+    saveGeneratedImagesMutation.isLoading || saveUserRequestMutation.isLoading;
+  return {
+    saveUserRequest,
+    saveGeneratedImages,
+    isQueryLoading,
+    isMutationLoading,
+  };
+}

--- a/src/hooks/saveImageRequest.ts
+++ b/src/hooks/saveImageRequest.ts
@@ -31,14 +31,14 @@ export function useSaveImageRequest() {
   //   }, [getGeneratedImagesQuery.data, setGeneratedImages]);
 
   const saveUserRequest = async ({
-    values,
+    value,
   }: {
-    values: { prompt: string; size: string; n: number };
+    value: { prompt: string; size: string; n: number };
   }) => {
     const userRequest = await saveUserRequestMutation.mutateAsync({
-      requestText: values.prompt,
-      imageSize: values.size,
-      numberOfImages: values.n,
+      requestText: value.prompt,
+      imageSize: value.size,
+      numberOfImages: value.n,
     });
     setUserRequestId(userRequest.id);
   };

--- a/src/pages/image-generation/index.tsx
+++ b/src/pages/image-generation/index.tsx
@@ -2,12 +2,11 @@ import Head from "next/head";
 import { ImageGenerationPromptForm } from "@/components/openai-playground/image-promp-form";
 import { Layout } from "@/components/layout";
 import { api } from "@/utils/api";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type * as z from "zod";
 import { type imgGenFormSchema } from "@/components/openai-playground/image-promp-form";
 import { ImgGallery } from "@/components/openai-playground/image-gallery";
-import { useSession } from "next-auth/react";
-import { Icons } from "@/components/icons";
+import { useSaveImageRequest } from "@/hooks/saveImageRequest";
 
 export type GenerateImageParams = {
   prompt: string;
@@ -15,63 +14,26 @@ export type GenerateImageParams = {
   size: "256x256" | "512x512" | "1024x1024";
 };
 export default function Home() {
-  const { data: session } = useSession();
   const [imgGenStatus, setImgGenStatus] = useState<
     "idle" | "pending" | "fulfilled" | "rejected"
   >("idle");
   const [generatedImages, setGeneratedImages] = useState<
     (string | undefined)[]
   >([]);
-  const [userRequestId, setUserRequestId] = useState<string | undefined>(
-    undefined
-  );
-
-  const saveUserRequestMutation =
-    api.imageGenerationLog.saveUserRequest.useMutation();
-  const saveGeneratedImagesMutation =
-    api.imageGenerationLog.saveGeneratedImages.useMutation();
-
-  const getGeneratedImagesQuery =
-    api.imageGenerationLog.getAllImagesGeneratedByUser.useQuery(
-      { numberOfImages: 10 },
-      {
-        enabled: !!session,
-      }
-    );
-
-  useEffect(() => {
-    if (!getGeneratedImagesQuery.data) return;
-    const requests = getGeneratedImagesQuery.data?.map(
-      (d) => d.generatedImages
-    );
-    if (!requests) return;
-    const images = requests.flat().map((d) => d.imageUrl);
-    setGeneratedImages(images);
-  }, [getGeneratedImagesQuery.data]);
+  const { saveUserRequest, isMutationLoading } = useSaveImageRequest();
 
   const generateImageMutation = api.openai.generateImage.useMutation({
     onMutate: () => {
-      // console.log("pending");
       setImgGenStatus("pending");
     },
     onError: () => {
-      // console.log(error);
       setImgGenStatus("rejected");
     },
     onSuccess: (data) => {
-      // console.log("success");
       if (!data.response) return;
       setImgGenStatus("fulfilled");
       const imgUrls = data.response?.map((d) => d.url!);
-      if (!imgUrls) return;
       setGeneratedImages((prev) => [...imgUrls, ...prev]);
-      // save generated images urls to db
-      if (userRequestId) {
-        saveGeneratedImagesMutation.mutate({
-          imageGenerationRequestId: userRequestId,
-          generatedImages: imgUrls,
-        });
-      }
     },
   });
 
@@ -88,22 +50,16 @@ export default function Home() {
     });
   };
   const submitHandler = async (values: z.infer<typeof imgGenFormSchema>) => {
-    //save user request and get id
-    const userRequest = await saveUserRequestMutation.mutateAsync({
-      requestText: values.prompt,
-      imageSize: values.size,
-      numberOfImages: values.n,
-    });
-    setUserRequestId(userRequest.id);
     generateImg({
       prompt: values.prompt,
       numberOfImages: values.n,
       size: values.size,
     });
+    //save user request and get id
+    await saveUserRequest({ values });
   };
-  const isLoading =
-    imgGenStatus === "pending" ||
-    (session && getGeneratedImagesQuery.isLoading);
+
+  const isMutating = imgGenStatus === "pending" || isMutationLoading;
   return (
     <>
       <Head>
@@ -117,19 +73,9 @@ export default function Home() {
             <ImageGenerationPromptForm
               // eslint-disable-next-line @typescript-eslint/no-misused-promises
               submitHandler={submitHandler}
-              isLoading={imgGenStatus === "pending"}
+              isLoading={isMutating}
             />
-            <div>
-              {isLoading && (
-                <div className="flex h-full w-full items-center justify-center">
-                  <Icons.spinner
-                    className="h-10 w-10 animate-spin"
-                    fill="black"
-                  />
-                </div>
-              )}
-              <ImgGallery images={generatedImages as string[]} />
-            </div>
+            <ImgGallery images={generatedImages as string[]} />
           </div>
         </main>
       </Layout>

--- a/src/pages/image-generation/index.tsx
+++ b/src/pages/image-generation/index.tsx
@@ -49,14 +49,14 @@ export default function Home() {
       size,
     });
   };
-  const submitHandler = async (values: z.infer<typeof imgGenFormSchema>) => {
+  const submitHandler = async (value: z.infer<typeof imgGenFormSchema>) => {
     generateImg({
-      prompt: values.prompt,
-      numberOfImages: values.n,
-      size: values.size,
+      prompt: value.prompt,
+      numberOfImages: value.n,
+      size: value.size,
     });
     //save user request and get id
-    await saveUserRequest({ values });
+    await saveUserRequest({ value });
   };
 
   const isMutating = imgGenStatus === "pending" || isMutationLoading;

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,6 +1,7 @@
 import { createTRPCRouter } from "@/server/api/trpc";
 import { openAiRouter } from "./routers/openai";
 import { openAiModels } from "./routers/openAiModels";
+import { imageGenerationLogRouter } from "./routers/imageGenerationLog";
 
 /**
  * This is the primary router for your server.
@@ -10,6 +11,7 @@ import { openAiModels } from "./routers/openAiModels";
 export const appRouter = createTRPCRouter({
   openai: openAiRouter,
   openAiModels: openAiModels,
+  imageGenerationLog: imageGenerationLogRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/imageGenerationLog.ts
+++ b/src/server/api/routers/imageGenerationLog.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
-import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
+import {
+  createTRPCRouter,
+  protectedProcedure,
+  publicProcedure,
+} from "@/server/api/trpc";
 
 export const imageGenerationLogRouter = createTRPCRouter({
-  saveUserRequest: protectedProcedure
+  saveUserRequest: publicProcedure
     .input(
       z.object({
         requestText: z.string(),
@@ -18,6 +22,22 @@ export const imageGenerationLogRouter = createTRPCRouter({
           numberOfImages: input.numberOfImages,
           imageSizeTitle: input.imageSize,
         },
+      });
+    }),
+
+  saveGeneratedImages: protectedProcedure
+    .input(
+      z.object({
+        imageGenerationRequestId: z.string(),
+        generatedImages: z.array(z.string()),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      await ctx.prisma.generatedImages.createMany({
+        data: input.generatedImages.map((generatedImage) => ({
+          imageGenerationRequestId: input.imageGenerationRequestId,
+          imageUrl: generatedImage,
+        })),
       });
     }),
 

--- a/src/server/api/routers/imageGenerationLog.ts
+++ b/src/server/api/routers/imageGenerationLog.ts
@@ -10,8 +10,8 @@ export const imageGenerationLogRouter = createTRPCRouter({
     .input(
       z.object({
         requestText: z.string(),
-        imageSize: z.string(),
         numberOfImages: z.number(),
+        imageSize: z.string(),
       })
     )
     .mutation(async ({ input, ctx }) => {
@@ -20,7 +20,7 @@ export const imageGenerationLogRouter = createTRPCRouter({
           userId: ctx.session?.user.id,
           requestText: input.requestText,
           numberOfImages: input.numberOfImages,
-          imageSizeTitle: input.imageSize,
+          imageSize: input.imageSize,
         },
       });
     }),

--- a/src/server/api/routers/imageGenerationLog.ts
+++ b/src/server/api/routers/imageGenerationLog.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
+
+export const imageGenerationLogRouter = createTRPCRouter({
+  saveUserRequest: protectedProcedure
+    .input(
+      z.object({
+        requestText: z.string(),
+        imageSize: z.string(),
+        numberOfImages: z.number(),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      return await ctx.prisma.imageGenerationRequest.create({
+        data: {
+          userId: ctx.session?.user.id,
+          requestText: input.requestText,
+          numberOfImages: input.numberOfImages,
+          imageSizeTitle: input.imageSize,
+        },
+      });
+    }),
+
+  getAllImagesGeneratedByUser: protectedProcedure.query(({ ctx }) => {
+    return ctx.prisma.imageGenerationRequest.findMany({
+      orderBy: {
+        createdAt: "desc",
+      },
+      where: {
+        userId: ctx.session.user.id,
+      },
+      include: {
+        generatedImages: true,
+      },
+    });
+  }),
+});

--- a/src/server/api/routers/imageGenerationLog.ts
+++ b/src/server/api/routers/imageGenerationLog.ts
@@ -25,7 +25,7 @@ export const imageGenerationLogRouter = createTRPCRouter({
       });
     }),
 
-  saveGeneratedImages: protectedProcedure
+  saveGeneratedImages: publicProcedure
     .input(
       z.object({
         imageGenerationRequestId: z.string(),
@@ -41,17 +41,24 @@ export const imageGenerationLogRouter = createTRPCRouter({
       });
     }),
 
-  getAllImagesGeneratedByUser: protectedProcedure.query(({ ctx }) => {
-    return ctx.prisma.imageGenerationRequest.findMany({
-      orderBy: {
-        createdAt: "desc",
-      },
-      where: {
-        userId: ctx.session.user.id,
-      },
-      include: {
-        generatedImages: true,
-      },
-    });
-  }),
+  getAllImagesGeneratedByUser: protectedProcedure
+    .input(
+      z.object({
+        numberOfImages: z.number().default(10),
+      })
+    )
+    .query(({ input, ctx }) => {
+      return ctx.prisma.imageGenerationRequest.findMany({
+        take: input.numberOfImages,
+        orderBy: {
+          createdAt: "desc",
+        },
+        where: {
+          userId: ctx.session.user.id,
+        },
+        include: {
+          generatedImages: true,
+        },
+      });
+    }),
 });


### PR DESCRIPTION
I implemented a log of what was requested and generated at the user level in the DB. Every time a user makes a request to the Open AI, related data (requestText, numberOfImages, imageSize, and userId) is stored in the DB. 

Initially, I wanted to store the URLs of generated images in the DB and receive them when a user opens the page. However, it turned out that images stored on the Open Ai server are available only for 1 hour. So for this feature, we need to consider storing images on our server.

Closes #11 