### PR TITLE
Alex/#3 GitHub workflow for staging deployement

### DIFF
--- a/.github/workflows/build-and-test-in-docker.yml
+++ b/.github/workflows/build-and-test-in-docker.yml
@@ -39,8 +39,7 @@ jobs:
 
       - name: Launch services with docker compose
         run: |
-          cd compose
-          docker compose up -d
+          docker compose -f ./compose/docker-compose.yml up -d
           sleep 30
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/deploy-to-vercel-preview.yaml
+++ b/.github/workflows/deploy-to-vercel-preview.yaml
@@ -18,12 +18,14 @@ env:
   GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
   GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [Build and Test]
+    types:
+      - completed
 jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Vercel CLI

--- a/.github/workflows/deploy-to-vercel-preview.yaml
+++ b/.github/workflows/deploy-to-vercel-preview.yaml
@@ -1,0 +1,36 @@
+name: Vercel Preview Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+  NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+  S3_PORT: ${{ secrets.S3_PORT }}
+  S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+  S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+  S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+  S3_USE_SSL: ${{ secrets.S3_USE_SSL }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  AZURE_AD_CLIENT_ID: ${{ secrets.AZURE_AD_CLIENT_ID }}
+  AZURE_AD_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+  AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+  GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+  GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Deploy-Preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-to-vercel-production.yaml
+++ b/.github/workflows/deploy-to-vercel-production.yaml
@@ -1,0 +1,31 @@
+name: Vercel Production Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  NEXTAUTH_URL: ${{ secrets.NEXTAUTH_URL }}
+  NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+  DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+  S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+  S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
+  S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+  AZURE_AD_CLIENT_ID: ${{ secrets.AZURE_AD_CLIENT_ID }}
+  AZURE_AD_CLIENT_SECRET: ${{ secrets.AZURE_AD_CLIENT_SECRET }}
+  AZURE_AD_TENANT_ID: ${{ secrets.AZURE_AD_TENANT_ID }}
+  GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+  GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+on: [workflow_dispatch]
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/cypress/e2e/mainMenuNavigation.cy.ts
+++ b/cypress/e2e/mainMenuNavigation.cy.ts
@@ -35,8 +35,9 @@ describe("Checks top panel content", () => {
     mainMenu.forEach((item) => {
       cy.dataCy(`desktop-navbar-${item.key}`)
         .should("have.attr", "href", item.href)
-        .should("have.text", item.englishLabel)
-        .click();
+        .should("have.text", item.englishLabel);
+      // click on the link
+      cy.dataCy(`desktop-navbar-${item.key}`).click();
 
       // check if the login page is loaded
       cy.url().should("include", item.href);

--- a/cypress/e2e/topPanel.cy.ts
+++ b/cypress/e2e/topPanel.cy.ts
@@ -51,9 +51,11 @@ describe("Checks top panel content", () => {
     // logout button and user info should be visible
     cy.dataCy("logoutButton").should("be.visible");
 
+    // wait for load to make sure the correct CSRF token is sent as a POST request to /api/auth/signout
+    cy.wait(3000);
     // log out
+    cy.intercept("/api/auth/csrf").as("signout");
     cy.dataCy("logoutButton").click();
-    cy.intercept("/api/auth/signout").as("signout");
     cy.wait("@signout");
 
     // check if the user is logged out

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -13,13 +13,7 @@ export const env = createEnv({
       process.env.NODE_ENV === "production"
         ? z.string().min(1)
         : z.string().min(1).optional(),
-    NEXTAUTH_URL: z.preprocess(
-      // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
-      // Since NextAuth.js automatically uses the VERCEL_URL if present.
-      (str) => process.env.VERCEL_URL ?? str,
-      // VERCEL_URL doesn't include `https` so it cant be validated as a URL
-      process.env.VERCEL ? z.string().min(1) : z.string().url()
-    ),
+    NEXTAUTH_URL: z.string().url(),
     OPENAI_API_KEY: z.string().min(1),
     // Add `.min(1) on ID and SECRET if you want to make sure they're not empty
     AZURE_AD_CLIENT_ID: z.string().min(1),


### PR DESCRIPTION
Created 2 workflow files for Vercel Preview Deployment and Vercel Production Deployment.
The preview deployment job is dependent on the integration test job.
The production deployment is set to run manually.

To run workflows it is necessary to add VERCEL_TOKEN, VERCEL_ORG_ID, and VERCEL_PROJECT_ID as secrets according to [the article](https://vercel.com/guides/how-can-i-use-github-actions-with-vercel):
1. Retrieve your [Vercel Access Token](https://vercel.com/guides/how-do-i-use-a-vercel-api-access-token)
2. Install the [Vercel CLI](https://vercel.com/cli) and run vercel login
3. Inside your folder, run vercel link to create a new Vercel project
4. Inside the generated .vercel folder, save the projectId and orgId from the project.json
5. Inside GitHub, add VERCEL_TOKEN, VERCEL_ORG_ID, and VERCEL_PROJECT_ID as secrets

Closes #3 
Related to #5 